### PR TITLE
Removing the not-very-helpful info println

### DIFF
--- a/knn/knn.go
+++ b/knn/knn.go
@@ -133,7 +133,6 @@ func (KNN *KNNClassifier) Predict(what base.FixedDataGrid) (base.FixedDataGrid, 
 			}
 		}
 	}
-	fmt.Println("Optimisations are switched off")
 
 	// Remove the Attributes which aren't numeric
 	allNumericAttrs := make([]base.Attribute, 0)


### PR DESCRIPTION
The line results in spammy logs and lives in a function that returns relevant values. Whether optimizations were used or not can be communicated other ways. Libraries should not print to stdout or stderr - it should be up to the consumer of the library to decide when to print.